### PR TITLE
handle invalid characters in a log_line

### DIFF
--- a/troubleshooting/shotgun_log_analyzer.rb
+++ b/troubleshooting/shotgun_log_analyzer.rb
@@ -11,11 +11,14 @@ STDERR.puts "Parsing the log..."
 all_queries = []
 
 def extract_timestamp(log_line)
+  # ignore any invalid characters that cause match to throw an ArgumentError
+  cleaned_line = log_line.force_encoding('UTF-8')
+  
   # Sep 19 13:52:22
-  ts_format_1 = log_line.match(/[a-zA-Z]{3} (\d{2}) (\d{2}):(\d{2}):(\d{2})/)
+  ts_format_1 = cleaned_line.match(/[a-zA-Z]{3} (\d{2}) (\d{2}):(\d{2}):(\d{2})/)
 
   # 2016-11-17T18:24:30
-  ts_format_2 = log_line.match(/(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})/)
+  ts_format_2 = cleaned_line.match(/(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})/)
 
   return ts_format_1 || ts_format_2
 end


### PR DESCRIPTION
We encountered a log_line yesterday with invalid characters in a search string:
display_name_caches.match_text LIKE '%����������%') AND (display_name_caches.project_id IN (163,103) OR ( display_name_caches.entity_type = 'Booking' AND display_name_caches.project_id IS NULL) OR display_name_caches.entity_type = 'ClientUser' OR display_name_caches.entity_type = 'CustomNonProjectEntity01' OR display_name_caches.entity_type = 'Department' OR display_name_caches.entity_type = 'CustomNonProjectEntity07' OR display_name_caches.entity_type = 'Group' OR display_name_caches.entity_type = 'HumanUser' OR display_name_caches.entity_type = 'CustomNonProjectEntity02' OR display_name_caches.entity_type = 'ApiUser' OR display_name_caches.entity_type = 'TaskTemplate' OR display_name_caches.entity_type = 'CustomNonProjectEntity03')) ORDER BY POSITION('����������' IN display_name_caches.match_text) asc NULLS LAST, POSITION('' IN REPLACE(display_name_caches.match_text, '����������', ''))
(I dunno if the bogus characters will actually render through in this message)

Invalid characters cause the 'match' method to throw an ArgumentError, which isn't handled (rescued) so the tool crashes.

Since this issue is just in the timestamp extraction method, the rest of the log_line doesn't actually matter so I suggest simply forcing it to UTF-8 before performing the matches.