### PR TITLE
new analyzer for tracking cause of 503 errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,4 @@
-# Shotgun Enterprise Toolbox
-This repository contains various tools that can be useful for Shotgun System Administrators
-
+# Shotgun Enterprise Toolbox This repository contains various tools that can be useful for Shotgun System Administrators
 ## How to use
 Clone this repository and follow the instructions related to the tools you want to use.
 
@@ -11,12 +9,77 @@ Scripts and cron jobs that can be used to gather helpful information about Shotg
 
 ## Troubleshooting
 
-### Shotgun Log Analysis
-Ruby script that produces a report underlying hot points, heaviest users and scripts, and slowest queries. The output
-of this script is a good starting point to troubleshoot performance issues related to usage patterns. Instructions
+### Shotgun Log Analyzer
+Ruby script that produces a report on underlying psql hot points, heaviest users
+and scripts, and slowest queries. The output of this script is a good starting
+point to troubleshoot performance issues related to usage patterns. Instructions
 in the script header.
 
-[Shotgun Log Analysis](./troubleshooting/shotgun_log_analyzer.rb)
+[Shotgun Log Analyzer](./troubleshooting/shotgun_log_analyzer.rb)
+
+### Log Chop
+
+This ruby script is also a prod log analyzer, but instead of focusing solely on psql queries and query time, it's focused primarily on discovering 'when' and 'what' for investigating the cause of 503 errors, by reporting on the following:
+
+- per-minute summaries of CPU time taken, broken down into Controller, Passenger, CRUD, and psql time. This also includes number of Controller requests per minute.
+- per-user summaries, broken down as above. Report will show top 5 user and top 5 script users for the whole log. the full user summary (not just the top 5) can be generated with the `-c` option.
+- per-user/per-minute summaries. This is a combination of per-minute overall usage PLUS a per-user breakdown per minute in the log file.
+
+Usage help can be obtained with `./log_chop.rb -h`, but here's a quick quide for order of operations:
+
+Parsing a log can be time-consuming if looking at an entire day's worth of activity, so this script is intended to both crop a log file to interesting time periods, and to analyze both full and cropped log files, especially if you already know the timestamps of the 503 incidents. First thing to do is to get the range of the log file in question with the `-r` option.  This option will parse a log and quickly give you the range of time (start and end, in UTC) covered in the log. For example:
+
+```
+./log_chop -r com_shotgunstudio_mystudio_production.log-20190130.gz
+            log begins: 2019-Jan-29 03:50:06 UTC / 2019-Jan-28 19:50:06 PST (-0800)
+              log ends: 2019-Jan-30 03:29:15 UTC / 2019-Jan-29 19:29:15 PST (-0800)
+        total duration: 23h 39m 09.000s
+time spent parsing log: 62.66 sec
+```
+
+With that output, you can then chop the full log into a smaller piece for analysis with the `-s` and `-e` options. In this example, we know that we experienced 503s at around 09:27 UTC, so it would be good to analyze the half-hour or so (or more, depending) surrounding the incident. We'll crop from 09:00 to 10:00.
+
+```
+./log_chop -s '2019-Jan-29 09:00:00' -e '2019-Jan-29 10:00:00' com_shotgunstudio_mystudio_production.log-20190130.gz
+looking at time from 2019-01-29 09:00:00 UTC to 2019-01-29 10:00:00 UTC.
+total window: 0 days, 1h 0m 0s
+parsing log elapsed time: 177.29 sec
+
+new slice file: timber_20190129_090000_to_20190129_100000.log.gz
+```
+
+The `timber_<timestamp>_to_<timestamp>.log.gz` files are the cropped log files that result from using the `-s/-e` options. Due to smaller size, they will be inherently quicker to analyze.
+
+We can employ the `-t` and `-u` options to perform the analysis. `-t` gives a per-minute global summary, while `-u` will give a per-user summary _for the period of time encompassed by the log file being analyzed_. So if you're looking at a whole day's log, the `-u` option will be less useful than looking at an hour or couple minutes' slice of time.
+
+On top of the previous options, using `-tu` together will give both a per-minute summary AND a per-user/per-minute summary, which is extremely granular and frankly a lot of data. On the other hand, this is very useful, but probably good to hold in reserve until you have a chopped log around the incident time. Until then, it's best to start with just the `-t` option to get a high-level read of trouble spots.
+
+For example:
+
+```
+./log_chop -tu com_shotgunstudio_mystudio_production.log-20190130.gz
+```
+
+**Note**: If you have more than 10 Passenger threads configured for your site, make sure to use the `-p` option so that the stats are calculated correctly; otherwise the stats will be generated with the assumption of a default 10 threads.
+
+#### How to read the output:
+
+- Controller is the initial request from the webapp or an api user. the Controller routes external requests into internal action. This is the best gauge for overall usage.
+- Passenger is the request handler. The queue has 10 threads and a backup shared queue of 100 requests. This is where we get the "ten minutes per minute" of possible processing time -- per minute, each Passenger thread has a minute of processor time, for a total of ten (or however many Passenger threads you have configged for your site). Large amounts of time spent here means that the queue is filling up and requests are waiting to be addressed, but big numbers here don't mean that things are crazy, it's just an indicator that the queue is active (though it could be full).
+- CRUD is what most requests get passed onto next, this is where Create, Read, Update, and Delete requests start to get processed.
+- SQL is where we're spending time handling queries that are generated from CRUD requests.
+
+Of these times, they generally fold up into each other. CRUD time envelops SQL time, and Controller time envelops CRUD time. Passenger time is an outlier and doesn't follow, since a request could spend a bit of time in the queue.
+
+Note that this output is very rough and not currently formatted well for client consumption (this was originally an internal tool), but some massaging could get it into an excel spreadsheet.
+
+TODO:
+
+- allow `log_chop.rb` to read non-gzipped files
+- add an option for pure csv output instead of text intended for terminal output.
+- combine user and api_user, as it's not terribly important to have them separated.
+
+[Shotgun Log Analyzer](./troubleshooting/log_chop.rb)
 
 ## Docker Setup
 Create setup menu for Shotgun Docker version.

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Usage help can be obtained with `./log_chop.rb -h`, but here's a quick quide for
 Parsing a log can be time-consuming if looking at an entire day's worth of activity, so this script is intended to both crop a log file to interesting time periods, and to analyze both full and cropped log files, especially if you already know the timestamps of the 503 incidents. First thing to do is to get the range of the log file in question with the `-r` option.  This option will parse a log and quickly give you the range of time (start and end, in UTC) covered in the log. For example:
 
 ```
-./log_chop -r com_shotgunstudio_mystudio_production.log-20190130.gz
+./log_chop.rb -r com_shotgunstudio_mystudio_production.log-20190130.gz
             log begins: 2019-Jan-29 03:50:06 UTC / 2019-Jan-28 19:50:06 PST (-0800)
               log ends: 2019-Jan-30 03:29:15 UTC / 2019-Jan-29 19:29:15 PST (-0800)
         total duration: 23h 39m 09.000s

--- a/troubleshooting/log_chop.rb
+++ b/troubleshooting/log_chop.rb
@@ -1,0 +1,479 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: false
+
+# TODO: on a bad minute, either chop a minute out or use current log to
+# pull any tasks longer than \d\{4,}\.\d\+ms and pull the request id,
+# and spit out relevant info
+
+$color_text = true
+
+# for parsing options
+require 'optparse'
+require 'ostruct'
+require 'pp'
+
+# for opening log files and checking timestamps
+require 'time'
+require 'zlib'
+
+# for color
+if Gem::Dependency.new('colorize').matching_specs.max_by(&:version).nil?
+  $color_text = false
+else
+  require 'colorize'
+end
+
+# for debugging
+require 'pry' unless Gem::Dependency.new('pry').matching_specs.max_by(&:version).nil?
+
+# collect arguments
+class OptParse
+  #
+  # Return a structure describing the options.
+  #
+  def self.parse(args)
+    # The options specified on the command line will be collected in *options*.
+    # We set default values here.
+    options = OpenStruct.new
+    options.start_time = ''
+    options.end_time = ''
+    options.threads = 10
+    options.complete = false
+
+    opt_parser = OptionParser.new do |opts|
+      opts.banner = 'Usage: log_chop.rb [options]'
+
+      opts.separator ''
+      opts.separator 'Specific options:'
+
+      opts.on('-u', '--analyze_user',
+              'Analyze chopped log file for amount of Controller, Crud, and',
+              'database time used; compared to available CPU time available.') do |u|
+        options.analyze_user = u
+      end
+
+      opts.on('-t', '--analyze_time',
+              'Analyze chopped log file for amount of Controller, Crud, and',
+              'database time used; compared to available CPU time available.') do |t|
+        options.analyze_time = t
+      end
+
+      opts.on('-c', '--complete',
+              'During an analysis, report all users instead of just top 10.') do |c|
+        options.complete = c
+      end
+
+      opts.on('-s', '--start START_TIME',
+              "start time for chopping log, in the format 'Mon DD HH:MM:SS'.",
+              'If used, must be used with the --end option.',
+              'Note that time must be supplied in UTC timezone') do |s|
+        options.start_time = s
+      end
+
+      opts.on('-e', '--end END_TIME',
+              "end time for chopping log, in the format 'Mon DD HH:MM:SS'.",
+              'If invoked, must be used with the --start option.',
+              'Note that time must be supplied in UTC timezone') do |e|
+        options.end_time = e
+      end
+
+      opts.on('-r', '--range',
+              'Display the start and end times of a given logfile.') do |r|
+        options.get_range = r
+      end
+
+      opts.on('-p', '--passenger_threads [NUMBER_THREADS]',
+              'Specify the humber of active Passenger threads (default 10).') do |p|
+        options.threads = p.to_i
+      end
+
+      opts.separator ''
+      opts.separator 'Common options:'
+
+      # No argument, shows at tail.  This will print an options summary.
+      # Try it and see!
+      opts.on_tail('-h', '--help', 'Show this message') do
+        puts opts
+        exit
+      end
+    end
+
+    begin
+      opt_parser.parse!(args)
+
+      if args.count == 0
+        ARGV << '-h'
+        opt_parser.parse!(args)
+      end
+
+      raise 'must supply logfile at end of switches.' unless args.count == 1 && args[0].end_with?('.gz')
+      # make sure that both start and end options are used together, show usage otherwise
+      if !options.start_time.empty? || !options.end_time.empty?
+        unless options.start_time && options.end_time
+          ARGV << '-h'
+          opt_parser.parse!(args)
+        end
+      end
+
+      options
+    rescue OptionParser::InvalidOption => e
+      puts e
+      puts opt_parser
+    end
+  end
+end
+
+def format_time(seconds)
+  Time.at(seconds).utc.strftime('%M:%S.%L')
+end
+
+def format_days(seconds)
+  days = (seconds / (60 * 60 * 24)).floor
+  hours = (seconds / (60 * 60) % 24).floor
+  minutes = ((seconds / 60) % 60).floor
+  seconds = (seconds % 60).floor
+
+  "#{days} days, #{hours}h #{minutes}m #{seconds}s"
+end
+
+def get_range(logfile)
+  f_utc = Time.new
+  l_utc = Time.new
+  duration = 0.0
+
+  Zlib::GzipReader.open(logfile) do |gz|
+    first_line = ''
+    last_line = ''
+    read_flag = true
+
+    gz.each_line do |l|
+      if read_flag
+        first_line = l[0..14]
+        read_flag = false
+      end
+      last_line = l[0..14] if gz.eof?
+    end
+
+    f_utc = Time.parse(first_line + ' UTC')
+    l_utc = Time.parse(last_line + ' UTC')
+    duration = l_utc - f_utc
+  end
+  [f_utc, l_utc, duration]
+rescue StandardError => e
+  e
+end
+
+def print_range(logfile)
+  t1 = Time.now
+  f_utc, l_utc, duration = get_range(logfile)
+  t2 = Time.now
+  puts "            log begins: #{f_utc.strftime('%Y-%b-%d %H:%M:%S %Z')} / #{f_utc.getlocal.strftime('%Y-%b-%d %H:%M:%S %Z (%z)')}"
+  puts "              log ends: #{l_utc.strftime('%Y-%b-%d %H:%M:%S %Z')} / #{l_utc.getlocal.strftime('%Y-%b-%d %H:%M:%S %Z (%z)')}"
+  puts "        total duration: #{Time.at(duration).utc.strftime('%Hh %Mm %S.%Ls')}"
+  puts "time spent parsing log: #{(t2 - t1).round(2)} sec\n\n"
+end
+
+def do_chop(options, logfile)
+  options.start_time += ' utc' unless options.start_time.downcase.end_with?(' utc')
+  options.end_time += ' utc' unless options.end_time.downcase.end_with?(' utc')
+  start_time = Time.parse(options.start_time)
+  end_time = Time.parse(options.end_time)
+
+  sts = start_time.strftime('%Y%m%d_%H%M%S')
+  ets = end_time.strftime('%Y%m%d_%H%M%S')
+  scope = end_time - start_time
+
+  puts "looking at time from #{start_time} to #{end_time}."
+  puts "total window: #{format_days(scope)}"
+
+  begin
+    Zlib::GzipReader.open(logfile) do |gzs|
+      # Time.at(seconds).utc.strftime('%d days %H:%M:%S.%L')
+
+      t1 = Time.now
+      filename = "timber_#{sts}_to_#{ets}.log.gz"
+
+      File.open(filename, 'w') do |file|
+        gzd = Zlib::GzipWriter.new(file)
+        gzs.each_line do |l|
+          yr = Time.now.year
+          mo = l[0..2]
+          dy = l[4..5]
+          hr = l[7..8]
+          mn = l[10..11]
+          sc = l[13..14]
+          timestamp = Time.new(yr, mo, dy, hr, mn, sc, -0)
+
+          gzd.write l if timestamp.between?(start_time, end_time)
+        end
+        gzd.close
+      end
+
+      t2 = Time.now
+      puts "parsing log elapsed time: #{(t2 - t1).round(2)} sec\n\n"
+      puts "new slice file: #{filename}"
+    end
+  rescue StandardError => e
+    puts e
+  end
+end
+
+def count(line_parts, duration_index)
+  timestamp = Time.parse(line_parts[0..2].join(' ') + ' UTC')
+  duration = line_parts[duration_index].tap { |t| t.slice!('ms') }.to_f unless duration_index.nil?
+  user_index = line_parts.index { |p| p.include?('user=') }
+  user_type = line_parts[user_index].split('=')[0]
+  user_type = 'client_user' if user_type.nil? && line_parts[user_index + 1] == '--'
+  user_name = line_parts[user_index].split('=')[1]
+  type_index = line_parts.index { |p| p.start_with?('INFO:') } + 1
+  type = line_parts[type_index].tap { |t| t.slice!(':') } unless type_index.nil?
+  parent_type = type.split('.')[0]
+  sub_type = type.split('.')[1..-1].join('.')
+  # puts "#{user_type}/#{user_name}: #{parent_type}, #{sub_type}, #{duration} milliseconds" unless duration.nil?
+
+  {
+    timestamp: timestamp,
+    user_name: user_name,
+    user_type: user_type,
+    duration: duration,
+    parent_type: parent_type,
+    sub_type: sub_type
+  }
+end
+
+def analyze(logfile)
+  start_time, end_time, duration = get_range(logfile)
+
+  Zlib::GzipReader.open(logfile) do |gz|
+    data = {}
+    idx = 1
+
+    puts "looking at time from #{start_time} to #{end_time}."
+    puts "total window: #{format_days(duration)}"
+    t1 = Time.now
+    gz.each_line do |l|
+      line_parts = l.split
+      if l.include?('INFO:')
+        duration_index = line_parts.index { |p| p =~ /\d+\.\d+ms/ }
+        data[idx.to_s] = count(line_parts, duration_index) unless duration_index.nil?
+      end
+      idx += 1
+    end
+    t2 = Time.now
+    puts "parsing log: #{(t2 - t1).round(2)} sec\n\n"
+    data
+  end
+end
+
+def calc_per_user(data, scope, options)
+  t1 = Time.now
+  debug_calc = false
+  start_time = data.first[1][:timestamp]
+
+  # stolen tip about how to create an auto-vivifying hash
+  per_user = Hash.new { |h, k| h[k] = Hash.new(&h.default_proc) }
+
+  # add up some times and initialize those that need to exist
+  data.each do |_k, v|
+    # initialize some defaults for each new username. If the key that we want to
+    # assign a value to is still a Hash, it's uninitialized.
+
+    puts "doing v! -- #{v}" if debug_calc
+    puts "per_user[#{v[:user_type]}][#{v[:user_name]}][#{v[:parent_type]}] -- #{per_user[v[:user_type]][v[:user_name]][:controller]}" if debug_calc
+    if per_user[v[:user_type]][v[:user_name]][:controller].is_a?(Hash)
+      per_user[v[:user_type]][v[:user_name]][:controller] = 0.0
+      per_user[v[:user_type]][v[:user_name]][:requests] = 0
+      per_user[v[:user_type]][v[:user_name]][:total] = 0.0
+      puts "initializing #{v[:user_name]} controller: #{per_user[v[:user_type]][v[:user_name]][:controller]}" if debug_calc
+    else
+      puts 'not initializing.' if debug_calc
+    end
+
+    # if the process type hasn't been recorded yet, initialize it for user_name
+    puts "per_user[#{v[:user_type]}][#{v[:user_name]}][#{v[:parent_type]}] -- #{per_user[v[:user_type]][v[:user_name]][v[:parent_type]]}" if debug_calc
+    if per_user[v[:user_type]][v[:user_name]][v[:parent_type]].is_a?(Hash)
+      per_user[v[:user_type]][v[:user_name]][v[:parent_type]] = v[:duration]
+      puts "initializing #{v[:user_name]}, #{v[:parent_type]}: #{v[:duration]}" if debug_calc
+    else
+      # if the category exists, sum up. these are the building blocks for the
+      # totals we want to generate later
+      foo = per_user[v[:user_type]][v[:user_name]][v[:parent_type]] if debug_calc
+      per_user[v[:user_type]][v[:user_name]][v[:parent_type]] += v[:duration]
+      puts "new value for #{v[:user_name]}, #{v[:parent_type]}: adding #{v[:duration]} to #{foo} -- #{per_user[v[:user_type]][v[:user_name]][v[:parent_type]]}" if debug_calc
+    end
+
+    per_user[v[:user_type]][v[:user_name]][:total] += v[:duration]
+
+    next unless v[:parent_type].to_s.end_with?('Controller')
+    bar = per_user[v[:user_type]][v[:user_name]][:controller] if debug_calc
+    per_user[v[:user_type]][v[:user_name]][:controller] += v[:duration]
+    per_user[v[:user_type]][v[:user_name]][:requests] += 1
+    puts "per_user[#{v[:user_type]}][#{v[:user_name]}][:controller] was #{bar}, now #{per_user[v[:user_type]][v[:user_name]][:controller]}" if debug_calc
+  end
+
+  main_categories = [:controller, :requests, 'Passenger', 'CRUD', 'SQL']
+
+  puts "#{start_time}: "
+  per_user.each do |user_type, users|
+    arr = users.sort_by { |_key, value| value[:total] }.reverse
+    puts "#{user_type}: (% of theoretical Passenger queue limit of 600 seconds; #{options.threads} threads * #{scope} seconds)"
+    arr.each_with_index do |i, idx|
+      next if options.complete == false && idx >= 5
+      formatted_times = {}
+      main_categories.each do |category|
+        if category == :requests
+          formatted_times[category.to_s] = "#{i[1][category]} |"
+        else
+          i[1][category] = 0.0 if i[1][category].is_a?(Hash)
+          ftime = format_time(i[1][category] / 1000).to_s
+          duration_ms = i[1][category].to_i
+          # (((total ms / (scope in s * 1000)) / 10 passenger queues) * 100 for percent)
+          percent = (((i[1][category] / (scope * 1000)) / options.threads) * 100).round(2).to_s
+          if $color_text
+            percent = if percent.to_f > 69
+                        percent.yellow
+                      elsif percent.to_f > 89
+                        percent.red
+                      else
+                        percent.green
+                      end
+          end
+          formatted_times[category.to_s] = "#{duration_ms}ms #{ftime}s #{percent}% "
+          formatted_times[category.to_s] << '|' unless category.to_s == main_categories.last.to_s
+        end
+      end
+
+      stats_output = "#{i[0]}: "
+      formatted_times.each do |cat, times|
+        next if cat == 'Passenger' && options.analyze_user && options.analyze_time
+        stats_output << if $color_text
+                          "#{cat.cyan}: #{times} "
+                        else
+                          "#{cat}: #{times} "
+                  end
+      end
+      puts stats_output
+    end
+    puts "\n"
+  end
+  t2 = Time.now
+  puts "time spent calulating user time: #{(t2 - t1).round(2)} sec\n" if debug_calc
+end
+
+def calc_per_time(data, duration, threads)
+  t1 = Time.now
+  time_stats = Hash.new { |h, k| h[k] = Hash.new(&h.default_proc) }
+  scope = duration < 60 ? duration : 60
+  data.each do |_k, v|
+    mark = v[:timestamp].utc.strftime('%H:%M')
+    if time_stats[mark][:controller].is_a?(Hash)
+      time_stats[mark][:controller] = 0.0
+      time_stats[mark][:requests] = 0
+      # puts "instantiating #{mark} controller: #{time_stats[mark][:controller]}"
+    end
+
+    if time_stats[mark][v[:parent_type]].is_a?(Hash)
+      time_stats[mark][v[:parent_type]] = v[:duration]
+      # puts "  instantiating #{v[:parent_type]}: #{v[:duration]}"
+    else
+      foo = time_stats[mark][v[:parent_type]]
+      time_stats[mark][v[:parent_type]] += v[:duration]
+      # puts "    adding #{foo} to #{v[:duration]}: #{time_stats[mark][v[:parent_type]]}"
+    end
+
+    if v[:parent_type].to_s.end_with?('Controller')
+      time_stats[mark][:controller] += v[:duration]
+      time_stats[mark][:requests] += 1
+    end
+  end
+
+  main_categories = [:controller, :requests, 'Passenger', 'CRUD', 'SQL']
+
+  puts "hour:minute: (% of capacity -- theoretical Passenger queue limit of 600 seconds; #{threads} threads * #{scope} seconds)"
+  time_stats.each do |timeslice, type|
+    formatted_times = {}
+    main_categories.each do |category|
+      type.each_with_index do |i, _idx|
+        next unless i[0] == category
+        if category == :requests
+          formatted_times[category.to_s] = "#{i[1]} |"
+        else
+          ftime = format_time(i[1] / 1000).to_s
+          duration_ms = i[1].to_i
+          # (((total ms / (scope in s * 1000)) / 10 passenger threads) * 100 for percent)
+          percent = (((i[1] / (scope * 1000)) / threads) * 100).round(2)
+          if $color_text
+            percent = if percent.to_f > 89
+                        percent.to_s.red
+                      elsif percent.to_f > 69
+                        percent.to_s.yellow
+                      else
+                        percent.to_s.green
+                      end
+          end
+          formatted_times[category.to_s] = "#{duration_ms}ms #{ftime}s #{percent}% "
+          formatted_times[category.to_s] << '|' unless category.to_s == main_categories.last.to_s
+        end
+      end
+    end
+
+    stats_output = "#{timeslice}: "
+    formatted_times.each do |cat, times|
+      stats_output << if $color_text
+                        "#{cat.cyan}: #{times} "
+                      else
+                        "#{cat}: #{times} "
+                end
+    end
+    puts stats_output
+  end
+  t2 = Time.now
+  puts "time spent calulating per-minute time: #{(t2 - t1).round(2)} sec\n\n"
+end
+
+def calc_user_per_time(data, _duration, options)
+  t1 = Time.now
+  start_time = data.first[1][:timestamp]
+  end_time = start_time + 60
+  slice_key = start_time.to_s
+  minute_data = {}
+  data.each do |d|
+    # puts d if debug_calc
+    minute_data[slice_key] = {} if minute_data[slice_key].nil?
+    if d[1][:timestamp] < end_time
+      minute_data[slice_key][d[0]] = d[1]
+      # puts "add to #{slice_key}" if debug_calc
+    else
+      slice_key = d[1][:timestamp].to_s
+      start_time = d[1][:timestamp]
+      end_time = start_time + 60
+      # puts "new key: #{slice_key}" if debug_calc
+      minute_data[slice_key] = {} if minute_data[slice_key].nil?
+      minute_data[slice_key][d[0]] = d[1]
+    end
+  end
+  t2 = Time.now
+  puts "time spent dividing data into per-minute time: #{(t2 - t1).round(2)} sec\n\n"
+
+  minute_data.each do |minute|
+    calc_per_user(minute[1], 60, options)
+  end
+end
+
+options = OptParse.parse(ARGV)
+logfile = ARGV[0]
+data = {}
+duration = 0.0
+
+print_range(logfile) if options.get_range
+do_chop(options, logfile) if !options.start_time.empty? && !options.end_time.empty?
+
+if options.analyze_user || options.analyze_time
+  data = analyze(logfile)
+  _f, _l, duration = get_range(logfile)
+end
+
+calc_per_user(data, duration, options) if options.analyze_user && !options.analyze_time
+calc_per_time(data, duration, options.threads) if options.analyze_time
+
+calc_user_per_time(data, duration, options) if options.analyze_user && options.analyze_time

--- a/troubleshooting/log_chop.rb
+++ b/troubleshooting/log_chop.rb
@@ -167,7 +167,7 @@ def print_range(logfile)
   t1 = Time.now
   f_utc, l_utc, duration = get_range(logfile)
   t2 = Time.now
-  puts "            log begins: #{f_utc.strftime('%Y-%b-%d %H:%M:%S %Z')} / #{f_utc.getlocal.strftime('%Y-%b-%d %H:%M:%S %Z (%z)')}"
+  puts "            log starts: #{f_utc.strftime('%Y-%b-%d %H:%M:%S %Z')} / #{f_utc.getlocal.strftime('%Y-%b-%d %H:%M:%S %Z (%z)')}"
   puts "              log ends: #{l_utc.strftime('%Y-%b-%d %H:%M:%S %Z')} / #{l_utc.getlocal.strftime('%Y-%b-%d %H:%M:%S %Z (%z)')}"
   puts "        total duration: #{Time.at(duration).utc.strftime('%Hh %Mm %S.%Ls')}"
   puts "time spent parsing log: #{(t2 - t1).round(2)} sec\n\n"


### PR DESCRIPTION
per the updated README.md, this new tool is very helpful in discerning the cause of 503 errors. the TS team has been using this tool and making it progressively more useful as we think of things to add to it. as the move to cloudOS won't support this kind of direct digging into the production logs, i thought it would at least be useful to polish it up and release it to local install clients. there are still a couple TODO items, but in its current state it's very workable and we can give it to people like blizzard and disney to whom we don't have vpn access.

there are definitely some chunks of redundant code that need to be collapsed into a more generalized function, but for now the end result is the main concern and it's doing a good job of getting to the _when, what_ and most of the _why_ for root causes.

as for cloudOS, whatever log access we have down the road would need to be able to perform this level of analysis.