### PR TITLE
Trim the version to the first digit to handle multi-digits MOSR

### DIFF
--- a/setup/postgresql_bootstrap_centos7.sh
+++ b/setup/postgresql_bootstrap_centos7.sh
@@ -32,6 +32,7 @@ fi
 
 # Os release number checker
 MOSR=`rpm -q --qf "%{VERSION}" $(rpm -q --whatprovides redhat-release)`
+MOSR=$(echo $MOSR | head -c 1)
 
 if (( $(echo "$MOSR == 7" |bc -l) )); then
    echo "RHEL 7/CentOS 7 detected ... continue installation"


### PR DESCRIPTION
RedHat 7.6 returns `7.6` here whereas Centos 7.6 returns `7`