### PR TITLE
A new way to install docker compose. Non pip installation.

### DIFF
--- a/setup/setup_validation_docker.sh
+++ b/setup/setup_validation_docker.sh
@@ -200,7 +200,10 @@ function install_all {
     sudo docker run hello-world
 
     # Install docker compose
-    sudo pip install docker-compose
+    sudo curl -L "https://github.com/docker/compose/releases/download/1.25.4/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+    sudo chmod +x /usr/local/bin/docker-compose
+    sudo ln -s /usr/local/bin/docker-compose /usr/bin/docker-compose
+    docker-compose --version
 }
 
 unset usage


### PR DESCRIPTION
A new way to install docker-compose. The pip way to install docker-compose failed due to error with request library.
Her is official documentation - https://docs.docker.com/compose/install/